### PR TITLE
Creates Training & Test Metadata files

### DIFF
--- a/ember/__init__.py
+++ b/ember/__init__.py
@@ -134,14 +134,23 @@ def create_metadata(data_dir):
 
     train_feature_paths = [os.path.join(data_dir, "train_features_{}.jsonl".format(i)) for i in range(6)]
     train_records = list(pool.imap(read_metadata_record, raw_feature_iterator(train_feature_paths)))
+
+    all_metadata_keys = ["sha256", "appeared", "subset", "label", "avclass"]
+    ordered_metadata_keys = [k for k in all_metadata_keys if k in train_records[0].keys()]
+
+    train_metadf = pd.DataFrame(train_records)[ordered_metadata_keys]
+    train_metadf.to_csv(os.path.join(data_dir, "train_metadata.csv"))
+
     train_records = [dict(record, **{"subset": "train"}) for record in train_records]
 
     test_feature_paths = [os.path.join(data_dir, "test_features.jsonl")]
     test_records = list(pool.imap(read_metadata_record, raw_feature_iterator(test_feature_paths)))
+
+    test_metadf = pd.DataFrame(test_records)[ordered_metadata_keys]
+    test_metadf.to_csv(os.path.join(data_dir, "test_metadata.csv"))
+
     test_records = [dict(record, **{"subset": "test"}) for record in test_records]
 
-    all_metadata_keys = ["sha256", "appeared", "subset", "label", "avclass"]
-    ordered_metadata_keys = [k for k in all_metadata_keys if k in train_records[0].keys()]
     metadf = pd.DataFrame(train_records + test_records)[ordered_metadata_keys]
     metadf.to_csv(os.path.join(data_dir, "metadata.csv"))
     return metadf

--- a/scripts/init_ember.py
+++ b/scripts/init_ember.py
@@ -11,6 +11,8 @@ def main():
     descr = "Train an ember model from a directory with raw feature files"
     parser = argparse.ArgumentParser(prog=prog, description=descr)
     parser.add_argument("-v", "--featureversion", type=int, default=2, help="EMBER feature version")
+    parser.add_argument("-m", "--metadata", type=bool, action="store_true", help="EMBER feature version")
+    parser.add_argument("-t", "--train", type=bool, action="store_true", help="EMBER feature version")
     parser.add_argument("datadir", metavar="DATADIR", type=str, help="Directory with raw features")
     parser.add_argument("--optimize", help="gridsearch to find best parameters", action="store_true")
     args = parser.parse_args()
@@ -24,24 +26,27 @@ def main():
         print("Creating vectorized features")
         ember.create_vectorized_features(args.datadir, args.featureversion)
 
-    params = {
-        "boosting": "gbdt",
-        "objective": "binary",
-        "num_iterations": 1000,
-        "learning_rate": 0.05,
-        "num_leaves": 2048,
-        "max_depth": 15,
-        "min_data_in_leaf": 50,
-        "feature_fraction": 0.5
-    }
-    if args.optimize:
-        params = ember.optimize_model(args.datadir)
-        print("Best parameters: ")
-        print(json.dumps(params, indent=2))
+        ember.create_metadata(args.datadir)
 
-    print("Training LightGBM model")
-    lgbm_model = ember.train_model(args.datadir, params, args.featureversion)
-    lgbm_model.save_model(os.path.join(args.datadir, "model.txt"))
+    if args.train:
+        params = {
+            "boosting": "gbdt",
+            "objective": "binary",
+            "num_iterations": 1000,
+            "learning_rate": 0.05,
+            "num_leaves": 2048,
+            "max_depth": 15,
+            "min_data_in_leaf": 50,
+            "feature_fraction": 0.5
+        }
+        if args.optimize:
+            params = ember.optimize_model(args.datadir)
+            print("Best parameters: ")
+            print(json.dumps(params, indent=2))
+
+        print("Training LightGBM model")
+        lgbm_model = ember.train_model(args.datadir, params, args.featureversion)
+        lgbm_model.save_model(os.path.join(args.datadir, "model.txt"))
 
 
 if __name__ == "__main__":

--- a/scripts/init_ember.py
+++ b/scripts/init_ember.py
@@ -11,8 +11,8 @@ def main():
     descr = "Train an ember model from a directory with raw feature files"
     parser = argparse.ArgumentParser(prog=prog, description=descr)
     parser.add_argument("-v", "--featureversion", type=int, default=2, help="EMBER feature version")
-    parser.add_argument("-m", "--metadata", action="store_true", help="EMBER feature version")
-    parser.add_argument("-t", "--train", action="store_true", help="EMBER feature version")
+    parser.add_argument("-m", "--metadata", action="store_true", help="Create metadata CSVs")
+    parser.add_argument("-t", "--train", action="store_true", help="Train an EMBER model")
     parser.add_argument("datadir", metavar="DATADIR", type=str, help="Directory with raw features")
     parser.add_argument("--optimize", help="gridsearch to find best parameters", action="store_true")
     args = parser.parse_args()
@@ -25,6 +25,7 @@ def main():
     if not (os.path.exists(X_train_path) and os.path.exists(y_train_path)):
         print("Creating vectorized features")
         ember.create_vectorized_features(args.datadir, args.featureversion)
+        
     if args.metadata:
         ember.create_metadata(args.datadir)
 

--- a/scripts/init_ember.py
+++ b/scripts/init_ember.py
@@ -25,8 +25,8 @@ def main():
     if not (os.path.exists(X_train_path) and os.path.exists(y_train_path)):
         print("Creating vectorized features")
         ember.create_vectorized_features(args.datadir, args.featureversion)
-        if args.metadata:
-            ember.create_metadata(args.datadir)
+    if args.metadata:
+        ember.create_metadata(args.datadir)
 
     if args.train:
         params = {

--- a/scripts/init_ember.py
+++ b/scripts/init_ember.py
@@ -25,8 +25,8 @@ def main():
     if not (os.path.exists(X_train_path) and os.path.exists(y_train_path)):
         print("Creating vectorized features")
         ember.create_vectorized_features(args.datadir, args.featureversion)
-
-        ember.create_metadata(args.datadir)
+        if args.metadata:
+            ember.create_metadata(args.datadir)
 
     if args.train:
         params = {

--- a/scripts/init_ember.py
+++ b/scripts/init_ember.py
@@ -11,8 +11,8 @@ def main():
     descr = "Train an ember model from a directory with raw feature files"
     parser = argparse.ArgumentParser(prog=prog, description=descr)
     parser.add_argument("-v", "--featureversion", type=int, default=2, help="EMBER feature version")
-    parser.add_argument("-m", "--metadata", type=bool, action="store_true", help="EMBER feature version")
-    parser.add_argument("-t", "--train", type=bool, action="store_true", help="EMBER feature version")
+    parser.add_argument("-m", "--metadata", action="store_true", help="EMBER feature version")
+    parser.add_argument("-t", "--train", action="store_true", help="EMBER feature version")
     parser.add_argument("datadir", metavar="DATADIR", type=str, help="Directory with raw features")
     parser.add_argument("--optimize", help="gridsearch to find best parameters", action="store_true")
     args = parser.parse_args()


### PR DESCRIPTION
Modifies the `create_metadata` function to also create files for the training and test sets. This makes experiments that rely on the metadata easier to code as you don't have to think about the train/test split of `metadata.csv`.

Also modifies the `train_ember.py` script to also optionally create these csvs. 